### PR TITLE
Update gorepoman to support vendoring

### DIFF
--- a/main/gorepoman/gorepoman.go
+++ b/main/gorepoman/gorepoman.go
@@ -26,8 +26,10 @@ import (
 )
 
 var (
-	srcDir  string
-	tempDir = filepath.Join(os.TempDir(), "gorepoman")
+	manifestLocation = flag.String("d", "",
+		"`directory` that contains the manifest file to manipulate. If not set,\n" +
+		"    	defaults to GOREPOMAN_ROOT environment variable. If that is not set\n" +
+		"    	either, then GOPATH/src will be used.")
 )
 
 // NOTES
@@ -37,173 +39,318 @@ var (
 func main() {
 	// Define the usage of the command line utility
 	flag.Usage = func() {
-		fmt.Fprintln(os.Stderr, "manage copies of external, upstream go dependencies/repositories")
-		fmt.Fprintln(os.Stderr, "")
-		fmt.Fprintln(os.Stderr, "gorepoman fetch <dep>                   - Download and install the specified dep")
-		fmt.Fprintln(os.Stderr, "gorepoman update <dep>                  - Attempt to freshen the specified dep")
-		fmt.Fprintln(os.Stderr, "gorepoman delete <dep>                  - Delete the specified dep")
-		fmt.Fprintln(os.Stderr, "gorepoman list                          - List all managed deps")
-		fmt.Fprintln(os.Stderr, "gorepoman list stale                    - List all out-of-date deps")
-		fmt.Fprintln(os.Stderr, "gorepoman list changed                  - List all deps with local changes")
-		fmt.Fprintln(os.Stderr, "gorepoman reconcile <dep> [cancel|done] - (advanced) Reconcile a locally-changed dep with the upstream")
-		fmt.Fprintln(os.Stderr, "")
-		fmt.Fprintln(os.Stderr, "<dep> is e.g. 'github.com/pkg/errors'")
+		os.Stderr.WriteString(
+`Manage copies of external, upstream go dependencies/repositories.
+
+gorepoman fetch <dep> [init]            - Download and install the specified dep
+gorepoman update <dep>                  - Attempt to freshen the specified dep
+gorepoman delete <dep>                  - Delete the specified dep
+gorepoman list                          - List all managed deps
+gorepoman list stale                    - List all out-of-date deps
+gorepoman list changed                  - List all deps with local changes
+gorepoman reconcile <dep> [cancel|done] - Reconcile a locally-changed dep with
+                                          the upstream repo
+
+<dep> is a Go package, e.g. 'github.com/pkg/errors'")
+
+When fetching a dep into a directory in which gorepoman has never been used
+before, use the init option. This will create the initial version of the
+gorepomanifest.json file. Otherwise, fetch requires the directory already
+contain a gorepomanifest.json file.
+
+All other operations require the directory have a gorepomanifest.json file.
+
+Flags must be passed before the action name. For example:
+    gorepoman -d some/package/vendor list
+Passing them after the action name will NOT work:
+    gorepoman list -d some/package/vendor
+
+Flags:`)
+		flag.PrintDefaults()
+		fmt.Fprintln(os.Stderr)
 	}
 
 	// Parse command line arguments
 	flag.Parse()
 
+	args := flag.Args()
+
 	// If no arguments were passed, display the help doc
-	if len(flag.Args()) == 0 {
+	if len(args) == 0 {
 		flag.Usage()
 		os.Exit(1)
 	}
 
-	if err := run(); err != nil {
+	action, args := args[0], args[1:]
+	var handler handlerFunc
+	switch strings.ToLower(action) {
+	case "list":
+		handler = listRepos
+	case "fetch":
+		handler = fetchRepo
+	case "update":
+		handler = updateRepo
+	case "delete":
+		handler = deleteRepo
+	case "reconcile":
+		handler = reconcileRepo
+	case "help":
+		flag.Usage()
+		return
+	default:
+		fmt.Fprintf(os.Stderr, "Unrecognized action %s - use 'gorepoman help' to see usage", action)
+		os.Exit(1)
+	}
+
+	// Create a temporary directory for us to work out of; we will want one no matter the action
+	tempDir := filepath.Join(os.TempDir(), "gorepoman")
+	os.RemoveAll(tempDir)
+	if err := os.Mkdir(tempDir, 0777); err != nil {
+		gorepoman.PrintError(os.Stderr, errors.Wrap(err, "Failed to create temporary working directory"))
+		os.Exit(1)
+	}
+	defer os.RemoveAll(tempDir)
+
+	srcDir, err := determineManifestLocation()
+	if err != nil {
+		gorepoman.PrintError(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	if err := handler(srcDir, tempDir, args); err != nil {
 		gorepoman.PrintError(os.Stderr, err)
 		os.Exit(1)
 	}
 }
 
-// Wrapper for the code that we want to run, so that we can be sure we always gracefully exit and clean up temp
-func run() (err error) {
-	// Sanity check the system setup.
-	// 1) We should be in a git repo.
-	out, err := gorepoman.BaseGit().Command("rev-parse", "--show-toplevel")
+// handlerFunc implements a single action supported by gorepoman (e.g. "list", "update", etc).
+// It should first validate args, then construct a manifest, then perform the action.
+type handlerFunc func(srcDir, tempDir string, args []string) error
+
+func determineManifestLocation() (string, error) {
+	loc := os.Getenv("GOREPOMAN_ROOT")
+	if *manifestLocation != "" {
+		loc = *manifestLocation
+	} else if loc == "" {
+		goPath := os.Getenv("GOPATH")
+		if len(goPath) == 0 {
+			return "", fmt.Errorf("failed to determine default manifest directory: GOPATH is not set")
+		}
+		goPaths := strings.Split(goPath, string(os.PathListSeparator))
+		loc = filepath.Join(goPaths[0], "src")
+	}
+
+	loc, err := filepath.Abs(loc)
 	if err != nil {
-		return errors.WithMessage(err, "You do not appear to be inside of a git repo, this tool is meant to be used in a git repo")
+		return "", fmt.Errorf("failed to determine absolute path of manifest directory: %s", err)
 	}
-	gitRepoStr := strings.TrimSpace(out)
-	gitRepoPath, err := filepath.Abs(gitRepoStr)
+	loc = filepath.Clean(loc)
+
+	fi, err := os.Stat(loc)
 	if err != nil {
-		return errors.Wrapf(err, "Could not resolve current git repo %q into an absolute path", gitRepoStr)
-	}
-
-	// 2) GOPATH should be defined, and it should be a subdirectory of the git repo.
-	goPaths := filepath.SplitList(os.Getenv("GOPATH"))
-	if len(goPaths) == 0 {
-		return errors.New("GOPATH is not defined, please define it")
-	}
-	goPathStr := goPaths[0]
-	goPath, err := filepath.Abs(goPathStr)
-	if err != nil {
-		return errors.Wrapf(err, "Could not resolve first GOPATH etnry %q into an absolute path", goPathStr)
-	}
-
-	if !strings.HasPrefix(goPath, gitRepoPath) {
-		return errors.Errorf("GOPATH=%q is not a subdirectory of the current git repo %q; see README.md", goPath, gitRepoPath)
-	}
-
-	if !gorepoman.Exists(goPath) {
-		return errors.Errorf("GOPATH=%q does not exist; please fix", goPath)
-	}
-
-	// Check to make sure that the source folder exists
-	srcDir = filepath.Join(goPath, "src")
-	if !gorepoman.Exists(srcDir) {
-		if err := os.Mkdir(srcDir, 0777); err != nil {
-			return gorepoman.ErrWithMessagef(err, "directory %q does not exist, and we couldn't create it!", srcDir)
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("manifest location does not exist: %s", loc)
+		} else {
+			return "", fmt.Errorf("failed to stat manifest location %s: %s", loc, err)
 		}
 	}
-
-	// Create a temporary directory for us to work out of, we will want one no matter the action
-	os.RemoveAll(tempDir)
-	if err := os.Mkdir(tempDir, 0777); err != nil {
-		return errors.Wrap(err, "Failed to create temporary working directory")
+	if !fi.IsDir() {
+		return "", fmt.Errorf("manifest location %s must be a directory", loc)
 	}
-	defer os.RemoveAll(tempDir)
 
-	// Read in the package manifest
+	if filepath.Base(loc) != "vendor" && !isGoPathSrcDir(loc) {
+		return "", fmt.Errorf("manifest location must be named 'vendor' or be the 'src' sub-directory of GOPATH")
+	}
+
+	if *manifestLocation == "" {
+		// No location was specified, so we decided on one based on environment. So
+		// let's be helpful to the user and show them the directory we came up with.
+		fmt.Printf("Using manifest directory %s\n", loc)
+	}
+
+	return loc, nil
+}
+
+func isGoPathSrcDir(loc string) bool {
+	if filepath.Base(loc) != "src" {
+		return false
+	}
+	dirStat, err := os.Stat(filepath.Dir(loc))
+	if err != nil {
+		return false
+	}
+	goPath := os.Getenv("GOPATH")
+	for _, path := range strings.Split(goPath, string(os.PathListSeparator)) {
+		pathStat, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		if os.SameFile(dirStat, pathStat) {
+			return true
+		}
+	}
+	return false
+}
+
+func fetchRepo(srcDir, tempDir string, args []string) error {
+	pkg, args, err := requirePackage(args)
+	if err != nil {
+		return err
+	}
+	option, err := getOption(args, "init")
+	if err != nil {
+		return err
+	}
+
+	var manifest *gorepoman.RepoManifest
+	if option == "init" {
+		manifest, err = gorepoman.CreateManifest(srcDir, tempDir)
+	} else {
+		manifest, err = gorepoman.ReadManifest(srcDir, tempDir)
+	}
+	if err != nil {
+		return err
+	}
+
+	return manifest.PkgFetch(pkg)
+}
+
+func listRepos(srcDir, tempDir string, args []string) error {
+	option, err := getOption(args, "stale", "changed")
+	if err != nil {
+		return err
+	}
+
 	manifest, err := gorepoman.ReadManifest(srcDir, tempDir)
 	if err != nil {
 		return err
 	}
 
-	// ---------- FINISH SETUP -----------
-
-	// Lets go to work!
-	return actionHandler(manifest, flag.Args())
+	switch option {
+	case "stale":
+		return manifest.PkgListStale()
+	case "changed":
+		return manifest.PkgListChanged()
+	default:
+		return manifest.PkgList()
+	}
 }
 
-func setOf(vals ...string) map[string]bool {
-	ret := map[string]bool{}
-	for _, v := range vals {
-		ret[v] = true
+func updateRepo(srcDir, tempDir string, args []string) error {
+	pkg, args, err := requirePackage(args)
+	if err != nil {
+		return err
 	}
-	return ret
+	if _, err = getOption(args); err != nil {
+		return err
+	}
+
+	manifest, err := gorepoman.ReadManifest(srcDir, tempDir)
+	if err != nil {
+		return err
+	}
+	if err := checkPackageExistsInManifest(manifest, pkg); err != nil {
+		return err
+	}
+
+	return manifest.PkgUpdate(pkg)
 }
 
-// General method to handle determining which action needs to be preformed
-func actionHandler(manifest *gorepoman.RepoManifest, args []string) error {
-	// Normalize the case of the action
-	action := strings.ToLower(args[0])
-
-	// List of actions we accept at the CLI
-	actions := setOf("fetch", "list", "update", "reconcile", "delete", "help")
-	options := setOf("done", "cancel", "stale", "changed")
-
-	// Confirm that the specified action is one we support
-	if !actions[action] {
-		return errors.Errorf("Unrecognized action %s - use 'gorepoman help' to see usage", action)
+func deleteRepo(srcDir, tempDir string, args []string) error {
+	pkg, args, err := requirePackage(args)
+	if err != nil {
+		return err
+	}
+	if _, err = getOption(args); err != nil {
+		return err
 	}
 
-	// Handle the help action
-	if action == "help" {
-		flag.Usage()
-		return nil
+	manifest, err := gorepoman.ReadManifest(srcDir, tempDir)
+	if err != nil {
+		return err
+	}
+	if err := checkPackageExistsInManifest(manifest, pkg); err != nil {
+		return err
 	}
 
-	// Handle the list action
-	if action == "list" {
-		if len(args) == 1 {
-			return manifest.PkgList()
-		} else if args[1] == "stale" {
-			return manifest.PkgListStale()
-		} else if args[1] == "changed" {
-			return manifest.PkgListChanged()
-		} else {
-			return errors.Errorf("Unrecognized argument to list: %s - Expecting stale or changed", args[1])
+	return manifest.PkgDelete(pkg, true)
+}
+
+func reconcileRepo(srcDir, tempDir string, args []string) error {
+	pkg, args, err := requirePackage(args)
+	if err != nil {
+		return err
+	}
+	if len(args) > 0 {
+		opt := strings.ToLower(args[0])
+		if (pkg == "cancel" || pkg == "done") && opt != "cancel" && opt != "done" {
+			// user specified package and option backwards; we'll allow it
+			pkg, args[0] = args[0], pkg
 		}
 	}
+	option, err := getOption(args, "cancel", "done")
+	if err != nil {
+		return err
+	}
 
-	// All of the other actions require at least one more parameter (the package to work with)
+	manifest, err := gorepoman.ReadManifest(srcDir, tempDir)
+	if err != nil {
+		return err
+	}
+	if err := checkPackageExistsInManifest(manifest, pkg); err != nil {
+		return err
+	}
+
+	switch option {
+	case "cancel":
+		return manifest.PkgReconcileCancel(pkg)
+	case "done":
+		return manifest.PkgReconcileDone(pkg)
+	default:
+		return manifest.PkgReconcile(pkg)
+	}
+}
+
+func requirePackage(args []string) (string, []string, error) {
+	if len(args) == 0 {
+		return "", nil, fmt.Errorf("You must specify a package.")
+	}
+	pkg, newArgs := args[0], args[1:]
+	pkg = strings.TrimRight(pkg, "/")
+	return pkg, newArgs, nil
+}
+
+func getOption(args []string, allowedOptions ...string) (string, error) {
+	if len(args) == 0 {
+		return "", nil
+	}
+	if len(allowedOptions) == 0 {
+		return "", fmt.Errorf("Unrecognized arguments: %v", strings.Join(args, " "))
+	}
 	if len(args) == 1 {
-		return errors.Errorf("Too few arguments for action %s - please specify a package", action)
+		// see if it's an allowed option
+		for _, opt := range allowedOptions {
+			if opt == args[0] {
+				return args[0], nil
+			}
+		}
 	}
-
-	// Trim leading and trailing slashes from provided package to put it in the standard format
-	pkg := strings.Trim(args[1], "/")
-
-	// If they have the options out of order
-	if options[pkg] || actions[pkg] {
-		fmt.Printf("You are trying to use the flag '%s' as a package name\n", pkg)
-		fmt.Println("Check the order of your parameters")
-		fmt.Println("")
-		flag.Usage()
-		return nil
+	for i, o := range allowedOptions {
+		allowedOptions[i] = fmt.Sprintf("%q", o)
 	}
+	return "", fmt.Errorf("Unrecognized arguments: %v\nExpecting %s or none", strings.Join(args, " "), strings.Join(allowedOptions, ", "))
+}
 
-	// Handle the fetch action
-	if action == "fetch" {
-		return manifest.PkgFetch(pkg)
-	}
-
-	// If the package isn't in our repo, let the user know
+func checkPackageExistsInManifest(manifest *gorepoman.RepoManifest, pkg string) error {
 	if !manifest.HasRepository(pkg) {
-		return errors.Errorf(`The package %s was not found in the manifest file
-Was it ever checked in in the first place?
-Or, the package you are looking for is actually a subpackage, and you need the name of the parent package`, pkg)
+		maybe := manifest.LikelyMatch(pkg)
+		if maybe == "" {
+			return fmt.Errorf(`The package %s was not found in the manifest file.
+Was it ever checked-in in the first place?`, pkg)
+		} else {
+			return fmt.Errorf(`The package %s was not found in the manifest file.
+Did you mean %s (which is present in manifest)?`, pkg, maybe)
+		}
 	}
-
-	// Handle the rest of the actions
-	switch action {
-	case "update":
-		return manifest.PkgUpdate(pkg)
-	case "reconcile":
-		return manifest.PkgReconcile(pkg, args)
-	case "delete":
-		return manifest.PkgDelete(pkg, true)
-	}
-
 	return nil
 }

--- a/manifest.go
+++ b/manifest.go
@@ -66,6 +66,19 @@ func (manifest *RepoManifest) HasRepository(packageName string) bool {
 	return ok
 }
 
+func (manifest *RepoManifest) LikelyMatch(packageName string) string {
+	for pkg := range manifest.Repositories {
+		prefix := pkg
+		if !strings.HasSuffix(prefix, "/") {
+			prefix = prefix + "/"
+		}
+		if strings.HasPrefix(packageName, prefix) {
+			return pkg
+		}
+	}
+	return ""
+}
+
 func (manifest *RepoManifest) RemoveRepository(packageName string) {
 	delete(manifest.Repositories, packageName)
 }
@@ -85,137 +98,17 @@ func (manifest *RepoManifest) Each(f func(string, PackageData) error) error {
 	return nil
 }
 
-// Handler for all of the package reconcile functionality
-func (manifest *RepoManifest) PkgReconcile(pkgName string, args []string) error {
+func (manifest *RepoManifest) packageLocation(pkgName string) string {
+	return filepath.Join(manifest.srcDir, pkgName)
+}
+
+// Handler for the package reconcile functionality
+func (manifest *RepoManifest) PkgReconcile(pkgName string) error {
 	pkg, ok := manifest.Repositories[pkgName]
 	if !ok {
 		panic(fmt.Sprintf("package %s not found in manifest, should not get here", pkgName))
 	}
 
-	// Check to see if they passed a stage argument, or if we are just getting started
-	if len(args) < 3 {
-		return manifest.recStart(pkgName, pkg)
-	}
-
-	// Figure out which step of the reconcile process we are in
-	stage := strings.ToLower(args[2])
-	switch stage {
-	case "cancel":
-		return manifest.recCancel(pkgName, pkg)
-	case "done":
-		return manifest.recDone(pkgName, pkg)
-	default:
-		return errors.Errorf("You are trying to work with the reconcile mode, but the extra parameter %s is not recognized", stage)
-	}
-}
-
-// Handler for the completion of reconcile mode
-func (manifest *RepoManifest) recDone(pkgName string, pkg PackageData) error {
-	exportPath := filepath.Join(exportDir, pkgName)
-
-	// Make sure a reconcile has been started
-	if !Exists(filepath.Join(exportPath, ".git")) {
-		return errors.Errorf("No export directory found at %q, no reconcile was ever started for package %s", exportDir, pkgName)
-	}
-
-	exportGit := TempGit(exportPath)
-	// Make sure the export directory is clean.
-	if modified, err := exportGit.IsLocallyModified(""); err != nil {
-		return err
-	} else if modified {
-		return errors.Errorf("export directory %q has local modifications; cannot reconcile; please commit or revert your changes", exportPath)
-	}
-
-	// Grab the hash of the reconciled package
-	exportHash, err := exportGit.CommitHash()
-	if err != nil {
-		return err
-	}
-
-	// Fetch latest version of the package so we have an up to date ancestry tree
-	fmt.Println("Confirming ancestry between reconcile repo and upstream source")
-	remote, err := exportGit.Remote() // Possibly update the remote.
-	if err != nil {
-		return err
-	}
-
-	remoteVersion, err := exportGit.LsRemote(remote)
-	if err != nil {
-		return err
-	}
-
-	// Fetch the remote version into the temp repo so we can compute a merge base.
-	if _, err := exportGit.Command("fetch", remote, remoteVersion); err != nil {
-		return err
-	}
-
-	// now run merge base to determine the common ancestor between the reconciled repo and the remote.
-	mergeBase, err := exportGit.MergeBase(remoteVersion, exportHash)
-	if err != nil {
-		return ErrWithMessagef(err, "could not find common ancestor between local commit %s and remote head %s; please fix", exportHash, remoteVersion)
-	}
-
-	// The "clean" content hash for change detection is the content hash of mergeBase
-	mergeBaseContentHash, err := exportGit.TreeHash(mergeBase, "")
-	if err != nil {
-		return err
-	}
-	fmt.Printf("Found common ancestor commit %s with content hash %s\n", mergeBase, mergeBaseContentHash)
-	fmt.Println("Copying reconcile directory back into your main repo")
-
-	pathInBaseRepo := filepath.Join(manifest.srcDir, pkgName)
-	if err := os.RemoveAll(pathInBaseRepo); err != nil {
-		return ErrWithMessagef(err, "Could not remove %q from main repo to finish reconcile", pathInBaseRepo)
-	}
-
-	// Copy the contents of our exported directory back into our main repo
-	if err := copyDir(exportPath, filepath.Dir(pathInBaseRepo)); err != nil {
-		return err
-	}
-	// Delete the .git subdir from our main repo.
-	if err := os.RemoveAll(filepath.Join(pathInBaseRepo, ".git")); err != nil {
-		return ErrWithMessagef(err, "Could not remove %q/.git from main repo to finish reconcile", pathInBaseRepo)
-	}
-	// git add the results so we're ready to commit
-	if _, err := BaseGit().Command("add", "-f", "--", pathInBaseRepo); err != nil {
-		return err
-	}
-
-	manifest.SetRepository(pkgName, pkg.GitRemote, mergeBase, mergeBaseContentHash)
-	fmt.Println("Writing new package manifest")
-	if err := manifest.writeManifest(); err != nil {
-		return err
-	}
-
-	// That's all done, manifest is rewritten, time to nuke the reconcile directory
-	if err := os.RemoveAll(exportPath); err != nil {
-		return errors.Wrapf(err, "Failed to clean up (remove) the reconcile directory at %s", exportPath)
-	}
-
-	fmt.Println("Reconcile complete!")
-	return nil
-}
-
-// Handler for canceling reconcile mode
-func (manifest *RepoManifest) recCancel(pkgName string, pkg PackageData) error {
-	// Path for this specific package to be exported to
-	exportPath := filepath.Join(exportDir, pkgName)
-
-	if !Exists(exportPath) {
-		return errors.Errorf("Unable to find a reconcile directory at %s - nothing to cancel. Did you ever start a reconcile for this package?", exportPath)
-	}
-
-	fmt.Println("Cancelling reconcile, cleaning up reconcile directory at " + exportPath)
-
-	if err := os.RemoveAll(exportPath); err != nil {
-		return errors.Wrapf(err, "Failed to remove reconcile working directory at %s", exportPath)
-	}
-
-	return nil
-}
-
-// Handler for starting reconcile mode
-func (manifest *RepoManifest) recStart(pkgName string, pkg PackageData) error {
 	// Check the status of the package to be upgraded
 	status, modified, err := manifest.packageStatus(pkgName)
 	if err != nil {
@@ -234,7 +127,7 @@ func (manifest *RepoManifest) recStart(pkgName string, pkg PackageData) error {
 	fmt.Printf("Prepping package %s for reconcile\n", pkgName)
 
 	// If the target package has local mods, abort.
-	pathInBaseRepo := filepath.Join(manifest.srcDir, pkgName)
+	pathInBaseRepo := manifest.packageLocation(pkgName)
 	if isModified, err := BaseGit().IsLocallyModified(pathInBaseRepo); err != nil {
 		return err
 	} else if isModified {
@@ -311,6 +204,116 @@ func (manifest *RepoManifest) recStart(pkgName string, pkg PackageData) error {
 	fmt.Printf("Successfully exported package %s to working directory:\n%s\n", pkgName, exportPath)
 	fmt.Println("Poke at it, shave the yaks, and then run this tool again with 'done' as a trailing param to move the changes back to our repo and strip the git metadata")
 	fmt.Println("If you for some reason want to cancel, run the tool again with 'cancel' as a trailing param")
+
+	return nil
+}
+
+// Handler for the completion of reconcile mode
+func (manifest *RepoManifest) PkgReconcileDone(pkgName string) error {
+	pkg, ok := manifest.Repositories[pkgName]
+	if !ok {
+		panic(fmt.Sprintf("package %s not found in manifest, should not get here", pkgName))
+	}
+
+	exportPath := filepath.Join(exportDir, pkgName)
+
+	// Make sure a reconcile has been started
+	if !Exists(filepath.Join(exportPath, ".git")) {
+		return errors.Errorf("No export directory found at %q, no reconcile was ever started for package %s", exportDir, pkgName)
+	}
+
+	exportGit := TempGit(exportPath)
+	// Make sure the export directory is clean.
+	if modified, err := exportGit.IsLocallyModified(""); err != nil {
+		return err
+	} else if modified {
+		return errors.Errorf("export directory %q has local modifications; cannot reconcile; please commit or revert your changes", exportPath)
+	}
+
+	// Grab the hash of the reconciled package
+	exportHash, err := exportGit.CommitHash()
+	if err != nil {
+		return err
+	}
+
+	// Fetch latest version of the package so we have an up to date ancestry tree
+	fmt.Println("Confirming ancestry between reconcile repo and upstream source")
+	remote, err := exportGit.Remote() // Possibly update the remote.
+	if err != nil {
+		return err
+	}
+
+	remoteVersion, err := exportGit.LsRemote(remote)
+	if err != nil {
+		return err
+	}
+
+	// Fetch the remote version into the temp repo so we can compute a merge base.
+	if _, err := exportGit.Command("fetch", remote, remoteVersion); err != nil {
+		return err
+	}
+
+	// now run merge base to determine the common ancestor between the reconciled repo and the remote.
+	mergeBase, err := exportGit.MergeBase(remoteVersion, exportHash)
+	if err != nil {
+		return ErrWithMessagef(err, "could not find common ancestor between local commit %s and remote head %s; please fix", exportHash, remoteVersion)
+	}
+
+	// The "clean" content hash for change detection is the content hash of mergeBase
+	mergeBaseContentHash, err := exportGit.TreeHash(mergeBase, "")
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Found common ancestor commit %s with content hash %s\n", mergeBase, mergeBaseContentHash)
+	fmt.Println("Copying reconcile directory back into your main repo")
+
+	pathInBaseRepo := manifest.packageLocation(pkgName)
+	if err := os.RemoveAll(pathInBaseRepo); err != nil {
+		return ErrWithMessagef(err, "Could not remove %q from main repo to finish reconcile", pathInBaseRepo)
+	}
+
+	// Copy the contents of our exported directory back into our main repo
+	if err := copyDir(exportPath, filepath.Dir(pathInBaseRepo)); err != nil {
+		return err
+	}
+	// Delete the .git subdir from our main repo.
+	if err := os.RemoveAll(filepath.Join(pathInBaseRepo, ".git")); err != nil {
+		return ErrWithMessagef(err, "Could not remove %q/.git from main repo to finish reconcile", pathInBaseRepo)
+	}
+	// git add the results so we're ready to commit
+	if _, err := BaseGit().Command("add", "-f", "--", pathInBaseRepo); err != nil {
+		return err
+	}
+
+	manifest.SetRepository(pkgName, pkg.GitRemote, mergeBase, mergeBaseContentHash)
+	fmt.Println("Writing new package manifest")
+	if err := manifest.writeManifest(); err != nil {
+		return err
+	}
+
+	// That's all done, manifest is rewritten, time to nuke the reconcile directory
+	if err := os.RemoveAll(exportPath); err != nil {
+		return errors.Wrapf(err, "Failed to clean up (remove) the reconcile directory at %s", exportPath)
+	}
+
+	fmt.Println("Reconcile complete!")
+	return nil
+}
+
+// Handler for canceling reconcile mode
+func (manifest *RepoManifest) PkgReconcileCancel(pkgName string) error {
+	// Path for this specific package to be exported to
+	exportPath := filepath.Join(exportDir, pkgName)
+
+	if !Exists(exportPath) {
+		return errors.Errorf("Unable to find a reconcile directory at %s - nothing to cancel. Did you ever start a reconcile for this package?", exportPath)
+	}
+
+	fmt.Println("Cancelling reconcile, cleaning up reconcile directory at " + exportPath)
+
+	if err := os.RemoveAll(exportPath); err != nil {
+		return errors.Wrapf(err, "Failed to remove reconcile working directory at %s", exportPath)
+	}
 
 	return nil
 }
@@ -408,8 +411,8 @@ func (manifest *RepoManifest) EachConcurrent(f func(pkgName string, pkg PackageD
 
 // List all of the packages that could use freshening
 func (manifest *RepoManifest) PkgListStale() error {
-	fmt.Println("Packages are stale if a newer version exists upstream")
-	fmt.Println("They should be brought up to date using 'gorepoman update <pkg>'")
+	fmt.Println("Packages are stale if a newer version exists upstream.")
+	fmt.Println("They should be brought up to date using 'gorepoman update <pkg>'.")
 
 	git := BaseGit()
 	results := manifest.EachConcurrent(func(pkgName string, pkg PackageData) (string, error) {
@@ -437,11 +440,12 @@ func (manifest *RepoManifest) PkgListStale() error {
 
 // List all of the packages that have had local changes made to them
 func (manifest *RepoManifest) PkgListChanged() error {
-	fmt.Println("Modified packages have been changed locally and don't match their corresponding upstream git hash")
+	fmt.Println("Modified packages have been changed locally and don't match their corresponding")
+	fmt.Println("upstream git hash.")
 
 	git := BaseGit()
 	results := manifest.EachConcurrent(func(pkgName string, pkg PackageData) (string, error) {
-		pathInBaseRepo := filepath.Join(manifest.srcDir, pkgName)
+		pathInBaseRepo := manifest.packageLocation(pkgName)
 		isLocallyModified, err := git.IsLocallyModified(pathInBaseRepo)
 		if err != nil {
 			return "", err
@@ -488,7 +492,7 @@ func (manifest *RepoManifest) packageStatus(pkgName string) (string, bool, error
 		panic(fmt.Sprintf("package %s not found in manifest, should not get here", pkgName))
 	}
 
-	pathInBaseRepo := filepath.Join(manifest.srcDir, pkgName)
+	pathInBaseRepo := manifest.packageLocation(pkgName)
 
 	// If the target package has local mods, abort.
 	if isModified, err := BaseGit().IsLocallyModified(pathInBaseRepo); err != nil {
@@ -550,7 +554,7 @@ func (manifest *RepoManifest) packageStatus(pkgName string) (string, bool, error
 // Returns the manifest data after it has been mutated because of the delete
 func (manifest *RepoManifest) PkgDelete(pkg string, writeManifest bool) error {
 	// It is in the manifest, so the package should exist in the repo - try and delete it
-	if err := os.RemoveAll(filepath.Join(manifest.srcDir, pkg)); err != nil {
+	if err := os.RemoveAll(manifest.packageLocation(pkg)); err != nil {
 		return errors.Wrapf(err, "Failed to delete package %s from the repository", pkg)
 	}
 
@@ -636,7 +640,7 @@ func (manifest *RepoManifest) installPackages() error {
 
 			fmt.Printf("Installing package %s ... \n", name)
 			// Create parent directory(ies) for the package (does nothing if it exists already)
-			if err := os.MkdirAll(filepath.Join(manifest.srcDir, filepath.Dir(name)), directoryPerm); err != nil {
+			if err := os.MkdirAll(manifest.packageLocation(filepath.Dir(name)), directoryPerm); err != nil {
 				return errors.Errorf("Failed to create parent directories for package %s", name)
 			}
 			// Remove git metadata from temp package
@@ -644,7 +648,7 @@ func (manifest *RepoManifest) installPackages() error {
 				return errors.Errorf("Failed to remove .git metadata from cloned package %s", name)
 			}
 			// Copy into new location in src
-			path := filepath.Join(manifest.srcDir, name)
+			path := manifest.packageLocation(name)
 			if err := os.Rename(filepath.Dir(newRepo), path); err != nil {
 				return errors.Wrapf(err, "Failed to move package %s from temporary directory to source folder", name)
 			}
@@ -672,12 +676,6 @@ func (manifest *RepoManifest) installPackages() error {
 // Helper function to display all of the packages currently in the manifest file
 // You can supply the list of packages if it is already loaded, or just nil, and it will be loaded here
 func (manifest *RepoManifest) PkgList() error {
-	if manifest == nil {
-		return errors.New("Unable to find a manifest file!")
-	}
-
-	fmt.Println("Packages currently in the repo/manifest:")
-
 	return manifest.Each(func(pkgName string, pkg PackageData) error {
 		fmt.Println(pkgName)
 		return nil
@@ -701,12 +699,12 @@ func goGet(pkg string, tmpDir string) error {
 }
 
 func (manifest *RepoManifest) Path() string {
-	return filepath.Join(filepath.Dir(manifest.srcDir), manifestFile)
+	return filepath.Join(manifest.srcDir, manifestFile)
 }
 
-// Read in the Manifest file containing the packages we already have checked in
-// Return an empty manifest if there is no manifest file to be found
-func ReadManifest(srcDir string, tmpDir string) (*RepoManifest, error) {
+// Read in the Manifest file containing the packages we already have fetched.
+// Returns an error if there is no manifest file to be found.
+func ReadManifest(srcDir, tmpDir string) (*RepoManifest, error) {
 	manifest := RepoManifest{
 		Repositories: make(RepoList),
 		Stale:        false,
@@ -716,19 +714,36 @@ func ReadManifest(srcDir string, tmpDir string) (*RepoManifest, error) {
 
 	manifestPath := manifest.Path()
 	if !Exists(manifestPath) {
-		fmt.Printf("no existing manifest found, creating new empty manifest at %s\n", manifestPath)
-		if err := manifest.writeManifest(); err != nil {
-			return nil, ErrWithMessagef(err, "create not create new manifest at %s", manifestPath)
-		}
+		return nil, fmt.Errorf("No existing manifest found at %s\n", manifestPath)
 	}
 
 	bytes, err := ioutil.ReadFile(manifestPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to read Manifest file")
+		return nil, errors.Wrap(err, "Failed to read manifest file")
 	}
 	// We wrote the JSON, so if it doesn't unmarshal it has probably been tampered with
 	if err := json.Unmarshal(bytes, &manifest.Repositories); err != nil {
-		return nil, errors.Wrap(err, "Failed to unmarshall JSON from Manifest, did the file get modified externally?")
+		return nil, errors.Wrap(err, "Failed to unmarshall JSON from manifest; did the file get modified externally?")
+	}
+
+	return &manifest, nil
+}
+
+// Create a new, empty Manifest file. Returns an error if a manifest file already exists.
+func CreateManifest(srcDir, tmpDir string) (*RepoManifest, error) {
+	manifest := RepoManifest{
+		Repositories: make(RepoList),
+		Stale:        false,
+		srcDir:       srcDir,
+		tmpDir:       tmpDir,
+	}
+
+	manifestPath := manifest.Path()
+	if Exists(manifestPath) {
+		return nil, fmt.Errorf("A manifest file already exists at %s", manifestPath)
+	}
+	if err := manifest.writeManifest(); err != nil {
+		return nil, ErrWithMessagef(err, "Could not create new manifest at %s", manifestPath)
 	}
 
 	return &manifest, nil

--- a/util.go
+++ b/util.go
@@ -33,9 +33,13 @@ func PrintError(w io.Writer, err error) {
 	msgs, stack := deconstruct(err)
 	for i := range msgs {
 		if i > 0 {
-			fmt.Fprint(w, "\n...caused by ")
+			fmt.Fprint(w, "...caused by ")
 		}
-		fmt.Fprint(w, msgs[len(msgs)-i-1])
+		msg := msgs[len(msgs)-i-1]
+		if msg[len(msg)-1] != '\n' {
+			msg = msg + "\n"
+		}
+		fmt.Fprint(w,msg)
 	}
 	if stack != nil {
 		fmt.Fprintf(w, "%+v\n", stack)


### PR DESCRIPTION
gorepoman supports vendoring!

* No longer requires that it manipulate GOPATH/src (still defaults to that).
* Can point gorepoman at a directory, which can be a "vendor" folder.
* Slight improvements to error messages.
* Non-trivial refactoring in the main package to handle the new way to
  initialize a manifest, based on the fact that it can be specified on the
  command line, and that it no longer auto-creates the manifest file. (You
  must use "fetch ... init" to create it.)

This last bit incurred quite a bit of "diff cheese". The issue was that, previously, all commands could share the same basic flow. When I tried to modify that one flow to handle lazily initializing the manifest for the `fetch` action, conditionally creating it, it felt really clunky. (There were already numerous conditionals for the various actions, and this change made it worse of a behemoth.) My solution was to split each command into its own flow with some helper methods to make the command implementations less redundant/more DRY. But that caused major textual differences in the main file.