### PR TITLE
Update package root check to match latest go cmd

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -712,7 +712,7 @@ func goGet(pkg string, tmpDir string) error {
 	_, err := execBinary("go", []string{"GOPATH=" + tmpDir}, "get", pkg)
 	if err != nil {
 		// If we downloaded the package, but couldn't find any gocode in the root
-		if strings.Contains(err.Error(), "no buildable Go source files") {
+		if strings.Contains(err.Error(), "no Go files in") || strings.Contains(err.Error(), "no buildable Go source files") {
 			fmt.Printf("No go source found in package root %s - probably a single repo that contains sub packages\n", pkg)
 			fmt.Println("The source was cloned successfully, should be fine")
 			return nil


### PR DESCRIPTION
When we `go get` a package, we have a manual check for the case when there are no buildable files, and it used to check the error message for the exact string "no buildable Go source files". However, as of [this commit](https://github.com/golang/go/commit/3445ece2128b0721cae4f6e84b159539acd314ef), the message was changed to "no Go files".

Updated the check to look for both strings, so it will work with both older and newer versions of go.