### PR TITLE
use correct ref for ls-remote; add go.mod

### DIFF
--- a/git.go
+++ b/git.go
@@ -117,6 +117,9 @@ var lsRemoteRegex = regexp.MustCompile(`^([0-9a-f]+)\s+\S+$`)
 // LsRemote returns the server-side commit SHA of the default branch (e.g. usually master) for
 // the given git remote url. Used for staleness checks.
 func (g *Gitter) LsRemote(remoteUrl, branch string) (string, error) {
+	if branch != "HEAD" {
+		branch = "refs/heads/" + branch
+	}
 	out, err := g.Command("ls-remote", remoteUrl, branch)
 	if err != nil {
 		return "", err

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/fullstorydev/gorepoman
+
+go 1.13
+
+require github.com/pkg/errors v0.9.1


### PR DESCRIPTION
This is our only internal change. Upstreaming this will let us unvendor this repo.